### PR TITLE
buildable by jdk-11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,11 +43,7 @@
                     <target>1.8</target>
                 </configuration>
             </plugin>
-        </plugins>
-    </build>
-    <!--
-    <build>
-        <plugins>
+            <!--
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
@@ -56,9 +52,9 @@
                     <debugForkedProcess>true</debugForkedProcess>
                 </configuration>
             </plugin>
+            -->
         </plugins>
     </build>
-    -->
     <dependencies>
         <dependency>
             <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,20 @@
     <groupId>org.jboss.churn</groupId>
     <artifactId>churn</artifactId>
     <version>1.0</version>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.0</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
     <!--
     <build>
         <plugins>


### PR DESCRIPTION
This makes churn buildable by jdk11. Unfortunately it kills jdk < 8, but I think it's time to move on.