### PR TITLE
use java from JAVA_HOME when set

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -82,7 +82,7 @@ if [ $# -gt 0 ]; then
     echo "invalid arguments $*"
 fi
  
-exec java ${HEAP_OPTS} \
+exec ${JAVA} ${HEAP_OPTS} \
     ${COOPS_OPTS} \
     ${GC_PRINT_OPTS} \
     ${GC_SPECIFIC_OPTS} \

--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -24,7 +24,20 @@
 # set up basic options needed for all runs
 # combine this with other scripts to complete setup
 # and then exec run.sh
-#
+
+# set up java
+if [ "x$JAVA_HOME" != "x" ]; then
+    export JAVA=${JAVA_HOME}/bin/java
+    echo "use java from JAVA_HOME [${JAVA}]"
+elif [ $( which java ) ]; then
+    export JAVA=$( which java )
+    echo "use java from PATH [${JAVA}]"
+else
+    echo "no java found!"
+    exit 1
+fi
+${JAVA} -version
+
 # set up heap size, gc print opts and default gc log file
 if [ -z "$HEAPSIZE" ]; then
     echo "setting heap size to 15g"


### PR DESCRIPTION
 * When JAVA_HOME is set, run scripts use that to run churn. This make it easier to switch java version. If not set, use default java from PATH.
 * Added simple `java -version` to print what java is used.
 * Exit nicely when no java found on neither JAVA_HOME or PATH.
