### PR TITLE
added -duration parameter

### DIFF
--- a/README
+++ b/README
@@ -39,13 +39,14 @@ which case the program uses suitable defaults
   -items I [default 4] how many million local/global work items in the work set
   -threads T [default 8] how many threads to use to do the processing
   -iterations N [default 200] how many times to update the local/gobal work set
+  -duration D [default off] how long in seconds should churn run. overwrites -iterations
   -computations C [default 32] how many computes/write operations are
    performed on each allocated object 
   -slices S [default 100] number of allocate/compute operations per timed task
   -yield Y [default -1] yield (Y = 0) or sleep (for Y msecs) at end of slice
   
 
-where B, I, T, N, C and S need to be supplied as positive integers
+where B, I, T, N, D, C and S need to be supplied as positive integers
 and Y may be 0 or a positive.
 
 Output
@@ -77,7 +78,9 @@ load or data set size.
 Each thread loops repeating updates to the work set N times. So, the
 total number of allocations and insertions into the local work set
 accumulated across all threads is (I * N) million and each thread
-creates (I / T) * N items.
+creates (I / T) * N items. Alternatively, when D is provided, new
+iterations are started, with same rules mentioned, until running
+time exceeds D seconds.
 
 Each time a chunk of I / T items is updated there is a 1 in 100 chance
 that the thread will purge all its entries from the global work set,

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -54,6 +54,12 @@ do
 	    GC_LOG_FILE=${GC_LOG_FILE}-n$1
 	    OUT_LOG_FILE=${OUT_LOG_FILE}-n$1
 	    shift;;
+    -duration)
+	    ARGS="$ARGS $1 $2"
+            shift
+	    GC_LOG_FILE=${GC_LOG_FILE}-d$1
+	    OUT_LOG_FILE=${OUT_LOG_FILE}-d$1
+	    shift;;
 	-computations)
 	    ARGS="$ARGS $1 $2"
             shift

--- a/src/main/java/org/jboss/churn/TestRunner.java
+++ b/src/main/java/org/jboss/churn/TestRunner.java
@@ -572,12 +572,20 @@ public class TestRunner extends Thread
         final long startTime = System.currentTimeMillis();
         // if duration is set, use that
         if (duration > 0) {
-            return counter -> {
-                long currentDuration = System.currentTimeMillis() - startTime;
-                return currentDuration / 1000 <= duration;
+            return new LoopCondition() {
+                @Override
+                public boolean check(int counter) {
+                    long currentDuration = System.currentTimeMillis() - startTime;
+                    return currentDuration / 1000 <= duration;
+                }
             };
         } else {
-            return iteration -> iteration < iterationCount;
+            return new LoopCondition() {
+                @Override
+                public boolean check(int iteration) {
+                    return iteration < iterationCount;
+                }
+            };
         }
     }
 


### PR DESCRIPTION
Hi Andrew,
this PR is adding new -duration parameter. If set, it overwrites -iterations and run threads for desired time duration. It is done with dynamic iterations-loop condition.
Please note that it uses lambdas, so it kills churn for Java 7 and less. I can change it to anonymous classes if needed.
Thanks