### PR TITLE
jdk9+ support JEP 158 logging

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -87,10 +87,9 @@ done
 if [ $# -gt 0 ]; then
     echo "invalid arguments $*"
 fi
- 
 exec ${JAVA} ${HEAP_OPTS} \
     ${COOPS_OPTS} \
     ${GC_PRINT_OPTS} \
     ${GC_SPECIFIC_OPTS} \
-    -Xloggc:${GC_LOG_FILE} \
+    $( eval echo ${LOG_OPTS} ) \
     -cp target/classes org.jboss.churn.TestRunner $ARGS > ${OUT_LOG_FILE} 2>&1

--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -46,6 +46,21 @@ else
     echo "heap size is $HEAPSIZE"
 fi
 export HEAP_OPTS="-Xms$HEAPSIZE -Xmx$HEAPSIZE"
-export GC_PRINT_OPTS="-XX:+PrintGCTimeStamps -XX:+PrintGCDetails -XX:+PrintGCApplicationStoppedTime -XX:+PrintGCApplicationConcurrentTime -verbose:gc"
 export OUT_LOG_FILE="outlog"
 export GC_LOG_FILE="gclog"
+
+
+# detect java version <= 8 and >= 9 because of changes introduced by JEP 158 (http://openjdk.java.net/jeps/158)
+# java <= 8 has just `java -version`, java >= 9 has also `java --version`
+# final GC_LOG_FILE is not known at the moment. We're going to eval $GC_LOG_FILE later in run.sh script
+${JAVA} --version &> /dev/null
+JV=$?
+if [[ ${JV} != 0 ]]; then
+    # jdk <= 8
+    export GC_PRINT_OPTS="-XX:+PrintGCTimeStamps -XX:+PrintGCDetails -XX:+PrintGCApplicationStoppedTime -XX:+PrintGCApplicationConcurrentTime -verbose:gc"
+    export LOG_OPTS='-Xloggc:$GC_LOG_FILE'
+else
+    # jdk >= 9
+    export GC_PRINT_OPTS=
+    export LOG_OPTS='-Xlog:gc=trace:${GC_LOG_FILE} -Xlog:gc=warning'
+fi


### PR DESCRIPTION
Hi Andrew,
JEP158 introduced new logging parameters for java. This patch updates run scripts to automatically detects java version <= 8 or >= 9 and handle command parameters according to that.
I'm detecting version by trying `java --version` (2 hyphens), which is available from java 9.
Another approach would be either duplicate run scripts for jdk9+, or some script parameter for current scripts. But I guess my approach should work seamlessly.