### PR TITLE
Add main-class to JAR manifest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,17 @@
                     <target>1.8</target>
                 </configuration>
             </plugin>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                  <configuration>
+                    <archive>
+                      <manifest>
+                        <mainClass>org.jboss.churn.TestRunner</mainClass>
+                      </manifest>
+                    </archive>
+                  </configuration>
+            </plugin>
             <!--
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This adds some maven machinery to generate main-class attribute in the generated JAR file. This allows churn to be run like java -jar churn-1.0.jar. I find this easier to use and more manageable than run scripts. My use-case is to build it using substratevm which also honors the main-class attribute when building with 'native-image -jar churn.jar'