### PR TITLE
Allow large range (1..MAXINT/1000) for -items parameter, and fix README

### DIFF
--- a/README
+++ b/README
@@ -36,7 +36,7 @@ The arguments to the program (and the run scripts) are optional in
 which case the program uses suitable defaults
 
   -blocks B [default 4] how many data blocks to allocate per work item
-  -items I [default 4] how many million local/global work items in the work set
+  -items I [default 4000] how many thousand local/global work items in the work set
   -threads T [default 8] how many threads to use to do the processing
   -iterations N [default 200] how many times to update the local/gobal work set
   -duration D [default off] how long in seconds should churn run. overwrites -iterations

--- a/src/main/java/org/jboss/churn/TestRunner.java
+++ b/src/main/java/org/jboss/churn/TestRunner.java
@@ -276,7 +276,7 @@ public class TestRunner extends Thread
                 } else if (args[i].equals("-items") && i + 1 < args.length) {
                     i++;
                     itemTotalThousands = Integer.valueOf(args[i]);
-                    if (itemTotalThousands <= 100 || itemTotalThousands > 20000) {
+                    if (itemTotalThousands <= 0 || itemTotalThousands > Integer.MAX_VALUE / 1000) {
                         usage(3, args[i]);
                     }
                 } else if (args[i].equals("-threads") && i + 1 < args.length) {


### PR DESCRIPTION
This is a less intrusive patch to achieve the same for me. I can run churn in a tiny environment like this now:

java -Xms100m -Xmx100m -Xmn50m -XX:+UseSerialGC -jar target/churn-1.0.jar -items 10

The parameter range is bounded by 1 (cannot handle 0 or negative) and MAXINT/1000 because anything larger would overflow when multiplied by 1000.

I also fixed the README to be a little less confusing.